### PR TITLE
a more bootiful example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ Next, you can view traces that went through the backend via http://localhost:941
 * This is a locally run zipkin service which keeps traces in memory
 
 ## Starting the Services
-In a separate tab or window, start each of [sleuth.webmvc.Frontend](/src/main/java/sleuth/webmvc/Frontend.java) and [sleuth.webmvc.Backend](/src/main/java/sleuth/webmvc/Backend.java):
+In a separate tab or window, start each of [sleuth.webmvc.frontend.Frontend](/src/main/java/sleuth/webmvc/Frontend.java) and [sleuth.webmvc.backend.Backend](/src/main/java/sleuth/webmvc/Backend.java):
 ```bash
-$ ./mvnw exec:java -Dexec.mainClass=sleuth.webmvc.Frontend
-$ ./mvnw exec:java -Dexec.mainClass=sleuth.webmvc.Backend
+$ ./mvnw exec:java -Dexec.mainClass=sleuth.webmvc.frontend.Frontend
+$ ./mvnw exec:java -Dexec.mainClass=sleuth.webmvc.backend.Backend
 ```
 
 Next, run [Zipkin](http://zipkin.io/), which stores and queries traces reported by the above services.

--- a/pom.xml
+++ b/pom.xml
@@ -1,48 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>sleuth.example</groupId>
-  <artifactId>sleuth-webmvc-example</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-  <packaging>jar</packaging>
+    <groupId>sleuth.example</groupId>
+    <artifactId>sleuth-webmvc-example</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
-  <name>sleuth-webmvc-example</name>
-  <description>Example using Spring Cloud Sleuth to trace RPCs from Spring Web MVC</description>
+    <name>sleuth-webmvc-example</name>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-sleuth</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-sleuth-zipkin</artifactId>
-    </dependency>
-  </dependencies>
+    <description>Example using Spring Cloud Sleuth to trace RPCs from Spring Web MVC</description>
 
-  <dependencyManagement>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.4.3.RELEASE</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
+    </properties>
     <dependencies>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-sleuth</artifactId>
-        <version>1.0.12.RELEASE</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
-  <repositories>
-    <repository>
-      <id>spring-snapshots</id>
-      <name>Spring Snapshots</name>
-      <url>https://repo.spring.io/libs-snapshot</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
+        <!--
+            Zipkin Server
+        -->
+        <dependency>
+            <groupId>io.zipkin.java</groupId>
+            <artifactId>zipkin-autoconfigure-ui</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.java</groupId>
+            <artifactId>zipkin-server</artifactId>
+        </dependency>
+
+        <!--
+            supports tracing the backend and frontend
+        -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-zipkin</artifactId>
+        </dependency>
+
+        <!--
+        ..
+        -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>Camden.SR4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/sleuth/webmvc/backend/Backend.java
+++ b/src/main/java/sleuth/webmvc/backend/Backend.java
@@ -1,10 +1,11 @@
-package sleuth.webmvc;
+package sleuth.webmvc.backend;
 
-import java.util.Date;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Date;
 
 @SpringBootApplication
 @RestController

--- a/src/main/java/sleuth/webmvc/frontend/Frontend.java
+++ b/src/main/java/sleuth/webmvc/frontend/Frontend.java
@@ -1,11 +1,11 @@
-package sleuth.webmvc;
+package sleuth.webmvc.frontend;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.sleuth.Sampler;
 import org.springframework.cloud.sleuth.sampler.AlwaysSampler;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,7 +16,11 @@ import org.springframework.web.client.RestTemplate;
 @CrossOrigin // So that javascript clients can originate the trace
 public class Frontend {
 
-  @Autowired RestTemplate template;
+  private final RestTemplate template;
+
+  public Frontend(@Lazy RestTemplate template) {
+    this.template = template;
+  }
 
   @RequestMapping("/")
   public String callBackend() {

--- a/src/main/java/sleuth/webmvc/server/ZipkinServer.java
+++ b/src/main/java/sleuth/webmvc/server/ZipkinServer.java
@@ -1,0 +1,14 @@
+package sleuth.webmvc.server;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import zipkin.server.EnableZipkinServer;
+
+@SpringBootApplication
+@EnableZipkinServer
+public class ZipkinServer {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ZipkinServer.class, "--server.port=9411");
+	}
+}


### PR DESCRIPTION

- the `pom.xml` now looks like any other Maven build generated from t… [Spring Initializr](http://start.spring.io)
- moved the `Backend` and `Frontend` to separate packages so that the auto-configuration of one module doesn't interact with the other
- preferred constructor injection for the `RestTemplate`. The `Resttemplate` now uses `@Lazy` so that the Zipkin auto-configuration can interact with the produced `RestTemplate` and so that we can inject the resulting bean in our `@RestController`
- Spring Boot makes it trivial to standup a Zipkin-server so this example, breaking with the others, _also_ includes a Zipkin server implementation.