### PR TITLE
Tweak docs to include compilation of example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Next, you can view traces that went through the backend via http://localhost:941
 ## Starting the Services
 In a separate tab or window, start each of [sleuth.webmvc.Frontend](/src/main/java/sleuth/webmvc/Frontend.java) and [sleuth.webmvc.Backend](/src/main/java/sleuth/webmvc/Backend.java):
 ```bash
-$ ./mvnw exec:java -Dexec.mainClass=sleuth.webmvc.Frontend
-$ ./mvnw exec:java -Dexec.mainClass=sleuth.webmvc.Backend
+$ ./mvnw compile exec:java -Dexec.mainClass=sleuth.webmvc.Frontend
+$ ./mvnw compile exec:java -Dexec.mainClass=sleuth.webmvc.Backend
 ```
 
 Next, run [Zipkin](http://zipkin.io/), which stores and queries traces reported by the above services.


### PR DESCRIPTION
I noticed that the `exec:java` goal doesn't trigger a compile, which caused a `ClassNotFoundException` for me when I tried to run the examples when starting afresh. Adding the `compile` target seems to be enough for these simple example services to start.