### PR TITLE
Uses EnableAutoConfiguration not SpringBootApplication to avoid scanning

### DIFF
--- a/src/main/java/sleuth/webmvc/Backend.java
+++ b/src/main/java/sleuth/webmvc/Backend.java
@@ -2,11 +2,11 @@ package sleuth.webmvc;
 
 import java.util.Date;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@SpringBootApplication
+@EnableAutoConfiguration
 @RestController
 public class Backend {
 

--- a/src/main/java/sleuth/webmvc/Frontend.java
+++ b/src/main/java/sleuth/webmvc/Frontend.java
@@ -1,20 +1,23 @@
 package sleuth.webmvc;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
-@SpringBootApplication
+@EnableAutoConfiguration
 @RestController
 @CrossOrigin // So that javascript can be hosted elsewhere
 public class Frontend {
 
+  @Autowired RestTemplate restTemplate;
+
   @RequestMapping("/") public String callBackend() {
-    return restTemplate().getForObject("http://localhost:9000/api", String.class);
+    return restTemplate.getForObject("http://localhost:9000/api", String.class);
   }
 
   @Bean RestTemplate restTemplate() {


### PR DESCRIPTION
To reduce problems in layering on this example, we remove the
`SpringBootApplication` annotation in favor of `EnableAutoConfiguration`
as `SpringBootApplication` scans and instantiates beans in the package.

We don't want the frontend to scan and load beans from the backend's
package basically.