### PR TITLE
Fix #15: tests fail if no TTY is present

### DIFF
--- a/scripts/runAcceptanceTests.sh
+++ b/scripts/runAcceptanceTests.sh
@@ -21,7 +21,7 @@ function our_docker_compose() {
 
 function docker_exec() {
     local SERVICE="$1"; shift
-    our_docker_compose exec "$SERVICE" "$@"
+    our_docker_compose exec -T "$SERVICE" "$@"
 }
 
 # ${RETRIES} number of times will try to curl to /health endpoint to passed port $1 and host $2


### PR DESCRIPTION
As discussed in #15.