### PR TITLE
Shows how to trace Dubbo without changing your code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 This is an example app where two Spring Boot (Java) services collaborate on an http request. Notably, timing of these requests are recorded into [Zipkin](http://zipkin.io/), a distributed tracing system. This allows you to see the how long the whole operation took, as well how much time was spent in each service.
 
 Here's an example of what it looks like
-<img width="972" alt="zipkin screen shot" src="https://cloud.githubusercontent.com/assets/64215/16300537/ff858dd6-3972-11e6-8e4c-4f7f4a6c707a.png">
+<img width="964" alt="zipkin screen shot" src="https://user-images.githubusercontent.com/64215/37188958-e22f4154-238c-11e8-91de-42a77420a122.png">
 
 This example was initially made for a [Distributed Tracing Webinar on June 30th, 2016](https://spring.io/blog/2016/05/24/webinar-understanding-microservice-latency-an-introduction-to-distributed-tracing-and-zipkin). There's probably room to enroll if it hasn't completed, yet, and you are interested in the general topic.
 
 # Implementation Overview
 
 Web requests are served by [Spring MVC](https://spring.io/guides/gs/rest-service/) controllers, and tracing is automatically performed for you by [Spring Cloud Sleuth](https://cloud.spring.io/spring-cloud-sleuth/).
+Backend requests are served by [Dubbo RPC](http://dubbo.io/)
 
 This example intentionally avoids advanced topics like async and load balancing, eventhough Spring Cloud Sleuth supports that, too. Once you get familiar with things, you can play with more interesting [Spring Cloud](http://projects.spring.io/spring-cloud/) components.
 
@@ -16,7 +17,7 @@ This example intentionally avoids advanced topics like async and load balancing,
 This example has two services: frontend and backend. They both report trace data to zipkin. To setup the demo, you need to start Frontend, Backend and Zipkin.
 
 Once the services are started, open http://localhost:8081/
-* This will call the backend (http://localhost:9000/api) and show the result, which defaults to a formatted date.
+* This will call the backend (dubbo://localhost:9000/api/printdate) and show the result, which defaults to a formatted date.
 
 Next, you can view traces that went through the backend via http://localhost:9411/?serviceName=backend
 * This is a locally run zipkin service which keeps traces in memory

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,20 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-sleuth-zipkin</artifactId>
     </dependency>
+
+    <!-- Adds dubbo infrastructure -->
+    <dependency>
+      <groupId>com.alibaba.spring.boot</groupId>
+      <artifactId>dubbo-spring-boot-starter</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+    <!-- Version is aligned using Brave's Bill of Materials (io.zipkin.brave:brave-bom)
+         To test a later version of brave, override it like -Dbrave.version=4.XX.X-SNAPSHOT
+         -->
+    <dependency>
+      <groupId>io.zipkin.brave</groupId>
+      <artifactId>brave-instrumentation-dubbo-rpc</artifactId>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/java/sleuth/webmvc/Api.java
+++ b/src/main/java/sleuth/webmvc/Api.java
@@ -1,0 +1,5 @@
+package sleuth.webmvc;
+
+public interface Api {
+  String printDate();
+}

--- a/src/main/java/sleuth/webmvc/Backend.java
+++ b/src/main/java/sleuth/webmvc/Backend.java
@@ -1,23 +1,28 @@
 package sleuth.webmvc;
 
+import com.alibaba.dubbo.config.annotation.Service;
+import com.alibaba.dubbo.spring.boot.annotation.EnableDubboConfiguration;
 import java.util.Date;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @EnableAutoConfiguration
-@RestController
-public class Backend {
+@EnableDubboConfiguration
+@Service(interfaceClass = Api.class)
+public class Backend implements Api {
 
-  @RequestMapping("/api") public String printDate() {
+  @Override public String printDate() {
     return new Date().toString();
   }
 
   public static void main(String[] args) {
     SpringApplication.run(Backend.class,
         "--spring.application.name=backend",
-        "--server.port=9000"
+        // These args allow dubbo to start without any web framework
+        "--spring.main.web-environment=false",
+        "--spring.dubbo.server=true",
+        "--spring.dubbo.registry=N/A",
+        "--spring.dubbo.protocol.port=9000"
     );
   }
 }

--- a/src/main/java/sleuth/webmvc/Frontend.java
+++ b/src/main/java/sleuth/webmvc/Frontend.java
@@ -1,27 +1,23 @@
 package sleuth.webmvc;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import com.alibaba.dubbo.config.annotation.Reference;
+import com.alibaba.dubbo.spring.boot.annotation.EnableDubboConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestTemplate;
 
 @EnableAutoConfiguration
 @RestController
 @CrossOrigin // So that javascript can be hosted elsewhere
+@EnableDubboConfiguration
 public class Frontend {
 
-  @Autowired RestTemplate restTemplate;
+  @Reference(url = "dubbo://127.0.0.1:9000") Api api;
 
   @RequestMapping("/") public String callBackend() {
-    return restTemplate.getForObject("http://localhost:9000/api", String.class);
-  }
-
-  @Bean RestTemplate restTemplate() {
-    return new RestTemplate();
+    return api.printDate();
   }
 
   public static void main(String[] args) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,7 @@
+# Adds tracing filters to every dubbo RPC call
+spring.dubbo.provider.filter=tracing
+spring.dubbo.consumer.filter=tracing
+
 # spring.application.name and server.port are set in the main methods,
 # so not done here
 logging.level.org.springframework.web=DEBUG


### PR DESCRIPTION
This changes the example to call a Dubbo backend instead of WebMVC
It uses Brave's RPC filter to add details to the existing trace.

https://github.com/openzipkin/brave/tree/master/instrumentation/dubbo-rpc