### PR TITLE
Shows how to trace JMS without changing your code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is an example app where two Spring Boot (Java) services collaborate on an http request. Notably, timing of these requests are recorded into [Zipkin](http://zipkin.io/), a distributed tracing system. This allows you to see the how long the whole operation took, as well how much time was spent in each service.
 
 Here's an example of what it looks like
-<img width="928" alt="Screenshot 2019-06-24 at 4 00 27 PM" src="https://user-images.githubusercontent.com/64215/60001539-3c756500-9699-11e9-92f2-d04b6c002214.png">
+<img width="928" alt="Screenshot 2019-06-24 at 4 00 27 PM" src="https://user-images.githubusercontent.com/572233/62698463-7eeec900-b9dd-11e9-8dbb-0056c0a6eaa1.png">
 
 This example was initially made for a [Distributed Tracing Webinar on June 30th, 2016](https://spring.io/blog/2016/05/24/webinar-understanding-microservice-latency-an-introduction-to-distributed-tracing-and-zipkin). There's probably room to enroll if it hasn't completed, yet, and you are interested in the general topic.
 
@@ -10,13 +10,16 @@ This example was initially made for a [Distributed Tracing Webinar on June 30th,
 
 Web requests are served by [Spring MVC](https://spring.io/guides/gs/rest-service/) controllers, and tracing is automatically performed for you by [Spring Cloud Sleuth](https://cloud.spring.io/spring-cloud-sleuth/).
 
+The backend listens for ActiveMQ messages using [spring-jms](https://spring.io/guides/gs/messaging-jms/).
+
 This example intentionally avoids advanced topics like async and load balancing, eventhough Spring Cloud Sleuth supports that, too. Once you get familiar with things, you can play with more interesting [Spring Cloud](http://projects.spring.io/spring-cloud/) components.
 
 # Running the example
 This example has two services: frontend and backend. They both report trace data to zipkin. To setup the demo, you need to start Frontend, Backend and Zipkin.
 
 Once the services are started, open http://localhost:8081/
-* This will call the backend (http://localhost:9000/api) and show the result, which defaults to a formatted date.
+* This will call the message queue (ActiveMQ tcp://localhost:61616 with queue "backend") and show no result as it is asynchronous.
+  * The backend listens for a message on that destination, dumping the message into the console.
 
 Next, you can view traces that went through the backend via http://localhost:9411/?serviceName=backend
 * This is a locally run zipkin service which keeps traces in memory
@@ -89,6 +92,11 @@ kafka-clients instrumentation when spring-kafka is present.
 
 https://github.com/openzipkin/brave/tree/master/instrumentation/kafka-clients
 https://github.com/spring-cloud/spring-cloud-sleuth/blob/v2.1.1.RELEASE/spring-cloud-sleuth-core/src/main/java/org/springframework/cloud/sleuth/instrument/messaging/TraceMessagingAutoConfiguration.java#L110
+
+## ActiveMQ Tracing
+[This](https://github.com/openzipkin/sleuth-webmvc-example/compare/add-jms-tracing-with-sleuth) changes the example to invoke the backend with ActiveMQ instead of WebMVC. Sleuth automatically configures Brave's spring-jms to add trace details.
+
+https://github.com/openzipkin/brave/tree/master/instrumentation/spring-jms
 
 ## Dubbo Tracing
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-activemq</artifactId>
+    </dependency>
     <!-- Sends trace data to zipkin over http (defaults to http://localhost:9411/api/v2/spans) -->
     <dependency>
       <groupId>org.springframework.cloud</groupId>

--- a/src/main/java/sleuth/webmvc/Backend.java
+++ b/src/main/java/sleuth/webmvc/Backend.java
@@ -1,23 +1,28 @@
 package sleuth.webmvc;
 
-import java.util.Date;
+import javax.jms.Message;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.jms.annotation.EnableJms;
+import org.springframework.jms.annotation.JmsListener;
 import org.springframework.web.bind.annotation.RestController;
 
 @EnableAutoConfiguration
 @RestController
+@EnableJms
 public class Backend {
 
-  @RequestMapping("/api") public String printDate() {
-    return new Date().toString();
+  @JmsListener(destination = "backend")
+  public void onMessage(Message m) {
+    System.err.println(m);
   }
+
 
   public static void main(String[] args) {
     SpringApplication.run(Backend.class,
         "--spring.application.name=backend",
-        "--server.port=9000"
+        "--server.port=0"
     );
   }
 }

--- a/src/main/java/sleuth/webmvc/Frontend.java
+++ b/src/main/java/sleuth/webmvc/Frontend.java
@@ -1,29 +1,26 @@
 package sleuth.webmvc;
 
+import java.util.Date;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.Bean;
+import org.springframework.jms.annotation.EnableJms;
+import org.springframework.jms.core.JmsTemplate;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.client.RestTemplate;
 
 @EnableAutoConfiguration
 @RestController
 @CrossOrigin // So that javascript can be hosted elsewhere
+@EnableJms
 public class Frontend {
 
-  @Autowired RestTemplate restTemplate;
+  @Autowired JmsTemplate jmsTemplate;
 
-  String backendBaseUrl = System.getProperty("spring.example.backendBaseUrl", "http://localhost:9000");
-
-  @RequestMapping("/") public String callBackend() {
-    return restTemplate.getForObject(backendBaseUrl + "/api", String.class);
-  }
-
-  @Bean RestTemplate restTemplate() {
-    return new RestTemplate();
+  @RequestMapping("/") public void callBackend() {
+    jmsTemplate.convertAndSend("backend", new Date());
   }
 
   public static void main(String[] args) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,6 @@ spring.sleuth.traceId128=true
 spring.sleuth.sampler.probability=1.0
 # Adds trace and span IDs to logs (when a trace is in progress)
 logging.pattern.level=[%X{X-B3-TraceId}/%X{X-B3-SpanId}] %-5p [%t] %C{2} - %m%n
+
+spring.activemq.broker-url=tcp://localhost:61616
+spring.zipkin.baseUrl: http://localhost:9411/


### PR DESCRIPTION
This changes the example to invoke the backend with ActiveMQ instead of WebMVC. Sleuth automatically configures Brave's jms-clients instrumentation when spring-jms is present.

This follow up issue #25.