### PR TITLE
Allow the Dockerfile to be self-built and add documentation on how to…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/docker/docker-compose.yml
+/docker/Dockerfile

--- a/README.md
+++ b/README.md
@@ -133,13 +133,13 @@ $ docker build -t openzipkin/example-sleuth-webmvc -f docker/Dockerfile .
 The backend can be started with a command similar to
 
 ```bash
-$ docker run -it --rm -p 9000 openzipkin/example-sleuth-webmvc backend
+$ docker run -it --rm -p 9000:9000 openzipkin/example-sleuth-webmvc backend
 ```
 
 The frontend can be started with a command similar to
             
 ```bash
-$ docker run -it --rm -p 8081 openzipkin/example-sleuth-webmvc frontend
+$ docker run -it --rm -p 8081:8081 openzipkin/example-sleuth-webmvc frontend
 ```
 
 ## Need something else not here?

--- a/README.md
+++ b/README.md
@@ -122,6 +122,26 @@ Under the covers, this uses the brave-opentracing bridge:
 
 https://github.com/openzipkin-contrib/brave-opentracing
 
+## Docker
+
+A docker image containing the example can be built using
+
+```bash
+$ docker build -t openzipkin/example-sleuth-webmvc -f docker/Dockerfile .
+```
+
+The backend can be started with a command similar to
+
+```bash
+$ docker run -it --rm -p 9000 openzipkin/example-sleuth-webmvc backend
+```
+
+The frontend can be started with a command similar to
+            
+```bash
+$ docker run -it --rm -p 8081 openzipkin/example-sleuth-webmvc frontend
+```
+
 ## Need something else not here?
 
 Sleuth layers on the [Brave](https://github.com/openzipkin/brave) project, so can re-use any code that

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM maven:3-jdk-11-slim
 
 ADD . /code
 
-RUN cd /code && mvn package -DskipTests=true
+RUN cd /code && mvn -B --no-transfer-progress package -DskipTests=true
 
 FROM gcr.io/distroless/java:11-debug
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,21 @@
-FROM circleci/openjdk:8-jdk
+FROM maven:3-jdk-11-slim
 
-COPY . /code
-WORKDIR /code
+ADD . /code
 
-ENTRYPOINT ["./docker/run.sh"]
+RUN cd /code && mvn package -DskipTests=true
+
+FROM gcr.io/distroless/java:11-debug
+
+RUN ["/busybox/sh", "-c", "adduser -g '' -h /zipkin -D zipkin"]
+
+WORKDIR /zipkin
+
+USER zipkin
+
+COPY --from=0 /code /zipkin
+ADD docker/run.sh /zipkin
+
+EXPOSE 8081
+EXPOSE 9000
+
+ENTRYPOINT ["/busybox/sh", "/zipkin/run.sh"]

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,6 +1,19 @@
 #!/bin/bash
 
-set -eou pipefail
+case "$1" in
+  f|frontend|Frontend )
+    CLASS_NAME=Frontend
+    ;;
+  b|backend|Backend )
+    CLASS_NAME=Backend
+    ;;
+  * )
+    echo "No command specified. Run the docker image with either the frontend or backend command, e.g.,
+    docker run -it --rm -p 8081 openzipkin/example-sleuth-webmvc frontend
+    docker run -it --rm -p 9000 openzipkin/example-sleuth-webmvc backend"
+    exit 1
+esac
 
-CLASS_NAME="$1"; shift
-java -cp "target/dependency/*:target/*" -Dlogging.level.org.springframework.cloud.sleuth=DEBUG -Dspring.zipkin.baseUrl=http://zipkin:9411 -Dspring.example.backendBaseUrl=http://backend:9000 sleuth.webmvc.$CLASS_NAME
+java -cp target/sleuth-webmvc-*-exec.jar -Dlogging.level.org.springframework.cloud.sleuth=DEBUG \
+  -Dspring.zipkin.baseUrl=http://zipkin:9411 -Dspring.example.backendBaseUrl=http://backend:9000 \
+  -Dloader.main=sleuth.webmvc.$CLASS_NAME org.springframework.boot.loader.PropertiesLauncher

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -9,8 +9,8 @@ case "$1" in
     ;;
   * )
     echo "No command specified. Run the docker image with either the frontend or backend command, e.g.,
-    docker run -it --rm -p 8081 openzipkin/example-sleuth-webmvc frontend
-    docker run -it --rm -p 9000 openzipkin/example-sleuth-webmvc backend"
+    docker run -it --rm -p 8081:8081 openzipkin/example-sleuth-webmvc frontend
+    docker run -it --rm -p 9000:9000 openzipkin/example-sleuth-webmvc backend"
     exit 1
 esac
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,4 +47,25 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>sleuth.webmvc.Backend</mainClass>
+          <classifier>exec</classifier>
+          <executable>true</executable>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/scripts/runAcceptanceTests.sh
+++ b/scripts/runAcceptanceTests.sh
@@ -24,14 +24,14 @@ function docker_exec() {
     our_docker_compose exec -T "$SERVICE" "$@"
 }
 
-# ${RETRIES} number of times will try to curl to /health endpoint to passed port $1 and host $2
-function curl_health_endpoint() {
+# ${RETRIES} number of times will try to fetch the /health endpoint to passed port $1 and host $2
+function fetch_health_endpoint() {
     local SERVICE="$1"
     local PORT="$2"
     local READY_FOR_TESTS=1
     for i in $( seq 1 "${RETRIES}" ); do
         sleep "${WAIT_TIME}"
-        docker_exec $SERVICE curl --fail -m 5 "127.0.0.1:${PORT}/actuator/health" && READY_FOR_TESTS=0 && break
+        docker_exec $SERVICE wget -q -O /dev/null -T 5 "127.0.0.1:${PORT}/actuator/health" && READY_FOR_TESTS=0 && break
         echo "Fail #$i/${RETRIES}... will try again in [${WAIT_TIME}] seconds"
     done
     if [[ "${READY_FOR_TESTS}" == 1 ]] ; then
@@ -41,14 +41,14 @@ function curl_health_endpoint() {
     return ${READY_FOR_TESTS}
 }
 
-# ${RETRIES} number of times will try to curl to /health endpoint to passed port $1 and localhost
-function curl_local_health_endpoint() {
-    curl_health_endpoint $1 "127.0.0.1"
+# ${RETRIES} number of times will try to fetch the /health endpoint to passed port $1 and localhost
+function fetch_local_health_endpoint() {
+    fetch_health_endpoint $1 "127.0.0.1"
 }
 
 function send_a_test_request() {
-    docker_exec frontend curl --fail -m 5 "127.0.0.1:8081" || return 1
-    docker_exec frontend curl --fail -m 5 "127.0.0.1:8081" || return 1
+    docker_exec frontend wget -q -O /dev/null -T 5 "127.0.0.1:8081" || return 1
+    docker_exec frontend wget -q -O /dev/null -T 5 "127.0.0.1:8081" || return 1
     echo -e "\n\nSuccessfully sent two test requests!!!"
 }
 
@@ -75,7 +75,7 @@ function check_trace() {
     for i in $( seq 1 "${RETRIES}" ); do
         sleep "${WAIT_TIME}"
         echo -e "Sending a GET to $URL_TO_CALL . This is the response:\n"
-        curl -sS --fail "$URL_TO_CALL" | grep ${STRING_TO_FIND} &&  READY_FOR_TESTS="yes" && break
+        wget -O - -q "$URL_TO_CALL" | grep ${STRING_TO_FIND} &&  READY_FOR_TESTS="yes" && break
         echo "Fail #$i/${RETRIES}... will try again in [${WAIT_TIME}] seconds"
     done
     if [[ "${READY_FOR_TESTS}" == "yes" ]] ; then
@@ -130,7 +130,7 @@ run_docker
 echo "Waiting for Zipkin to start"
 sleep 15
 echo "Assuming that Zipkin is running"
-curl_health_endpoint frontend 8081
-curl_health_endpoint backend 9000
+fetch_health_endpoint frontend 8081
+fetch_health_endpoint backend 9000
 send_a_test_request
 check_trace

--- a/scripts/runAcceptanceTests.sh
+++ b/scripts/runAcceptanceTests.sh
@@ -56,6 +56,7 @@ function run_docker() {
     our_docker_compose kill || echo "Failed to kill any docker containers"
     our_docker_compose pull
     our_docker_compose up --build -d
+    our_docker_compose logs --follow zipkin > "${LOGS_DIR}/Zipkin.log" &
     our_docker_compose logs --follow frontend > "${LOGS_DIR}/Frontend.log" &
     our_docker_compose logs --follow backend > "${LOGS_DIR}/Backend.log" &
 }

--- a/scripts/runAcceptanceTests.sh
+++ b/scripts/runAcceptanceTests.sh
@@ -75,7 +75,7 @@ function check_trace() {
     for i in $( seq 1 "${RETRIES}" ); do
         sleep "${WAIT_TIME}"
         echo -e "Sending a GET to $URL_TO_CALL . This is the response:\n"
-        wget -S -O - -q "$URL_TO_CALL" -T 5 # | grep ${STRING_TO_FIND} &&  READY_FOR_TESTS="yes" && break
+        wget -S -O - "$URL_TO_CALL" -T 5 # | grep ${STRING_TO_FIND} &&  READY_FOR_TESTS="yes" && break
         echo "Fail #$i/${RETRIES}... will try again in [${WAIT_TIME}] seconds"
     done
     if [[ "${READY_FOR_TESTS}" == "yes" ]] ; then

--- a/scripts/runAcceptanceTests.sh
+++ b/scripts/runAcceptanceTests.sh
@@ -76,7 +76,7 @@ function check_trace() {
     for i in $( seq 1 "${RETRIES}" ); do
         sleep "${WAIT_TIME}"
         echo -e "Sending a GET to $URL_TO_CALL . This is the response:\n"
-        curl -sS --fail "$URL_TO_CALL" | grep ${STRING_TO_FIND} &&  READY_FOR_TESTS="yes" && break
+        docker_exec zipkin wget -S -O - "$URL_TO_CALL" -T 5 | grep ${STRING_TO_FIND} && READY_FOR_TESTS="yes" && break
         echo "Fail #$i/${RETRIES}... will try again in [${WAIT_TIME}] seconds"
     done
     if [[ "${READY_FOR_TESTS}" == "yes" ]] ; then

--- a/scripts/runAcceptanceTests.sh
+++ b/scripts/runAcceptanceTests.sh
@@ -75,7 +75,7 @@ function check_trace() {
     for i in $( seq 1 "${RETRIES}" ); do
         sleep "${WAIT_TIME}"
         echo -e "Sending a GET to $URL_TO_CALL . This is the response:\n"
-        wget -O - -q "$URL_TO_CALL" | grep ${STRING_TO_FIND} &&  READY_FOR_TESTS="yes" && break
+        wget -S -O - -q "$URL_TO_CALL" | grep ${STRING_TO_FIND} &&  READY_FOR_TESTS="yes" && break
         echo "Fail #$i/${RETRIES}... will try again in [${WAIT_TIME}] seconds"
     done
     if [[ "${READY_FOR_TESTS}" == "yes" ]] ; then

--- a/scripts/runAcceptanceTests.sh
+++ b/scripts/runAcceptanceTests.sh
@@ -75,7 +75,7 @@ function check_trace() {
     for i in $( seq 1 "${RETRIES}" ); do
         sleep "${WAIT_TIME}"
         echo -e "Sending a GET to $URL_TO_CALL . This is the response:\n"
-        wget -S -O - -q "$URL_TO_CALL" -T 5 | grep ${STRING_TO_FIND} &&  READY_FOR_TESTS="yes" && break
+        wget -S -O - -q "$URL_TO_CALL" -T 5 # | grep ${STRING_TO_FIND} &&  READY_FOR_TESTS="yes" && break
         echo "Fail #$i/${RETRIES}... will try again in [${WAIT_TIME}] seconds"
     done
     if [[ "${READY_FOR_TESTS}" == "yes" ]] ; then

--- a/scripts/runAcceptanceTests.sh
+++ b/scripts/runAcceptanceTests.sh
@@ -76,7 +76,7 @@ function check_trace() {
     for i in $( seq 1 "${RETRIES}" ); do
         sleep "${WAIT_TIME}"
         echo -e "Sending a GET to $URL_TO_CALL . This is the response:\n"
-        wget -S -O - "$URL_TO_CALL" -T 5 # | grep ${STRING_TO_FIND} &&  READY_FOR_TESTS="yes" && break
+        curl -sS --fail "$URL_TO_CALL" | grep ${STRING_TO_FIND} &&  READY_FOR_TESTS="yes" && break
         echo "Fail #$i/${RETRIES}... will try again in [${WAIT_TIME}] seconds"
     done
     if [[ "${READY_FOR_TESTS}" == "yes" ]] ; then

--- a/scripts/runAcceptanceTests.sh
+++ b/scripts/runAcceptanceTests.sh
@@ -75,7 +75,7 @@ function check_trace() {
     for i in $( seq 1 "${RETRIES}" ); do
         sleep "${WAIT_TIME}"
         echo -e "Sending a GET to $URL_TO_CALL . This is the response:\n"
-        wget -S -O - -q "$URL_TO_CALL" | grep ${STRING_TO_FIND} &&  READY_FOR_TESTS="yes" && break
+        wget -S -O - -q "$URL_TO_CALL" -T 5 | grep ${STRING_TO_FIND} &&  READY_FOR_TESTS="yes" && break
         echo "Fail #$i/${RETRIES}... will try again in [${WAIT_TIME}] seconds"
     done
     if [[ "${READY_FOR_TESTS}" == "yes" ]] ; then


### PR DESCRIPTION
… run it.

Open to any suggestions. I went with a single image with commands to control backend / frontend since the difference of separating out with a `-`, or a `:`, or a ` ` didn't seem that big, but this ensures the same code is only downloaded once onto a dev's machine without other trickiness. I think it also provides the flexibility e.g., for kafka, mentioned on the issue.

Now that the `Dockerfile` builds by itself, I suggest we set up Docker Hub to automatically build on master push - it's a simple and good way of publishing docker images for at least this sort that doesn't use Maven Central as a source of truth.

I am thinking after this is published, we could add it to the normal `openzipkin/docker` `docker-compose.yml`.

Fixes #27 