### PR TITLE
Expose frontend and backend when running via docker-compose

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,11 @@
+# Running via docker-compose
+
+Note: The below presumes you have Docker and Docker Compose installed. You can [find an installer for your OS here](https://docs.docker.com/compose/install/).
+
+To run a stack with the frontend, backend, and Zipkin server, simply run the following: `docker-compose up`
+
+This will create the following endpoints:
+
+1. Zipkin: http://localhost:3000
+2. Frontend: http://localhost:8081
+3. Backend: http://localhost:8082

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,14 +10,20 @@ services:
       # Port used for the Zipkin UI and HTTP Api
       - 9411:9411
 
+  # Expose the frontend on http://localhost:8081
   frontend:
     build:
       context: ../
       dockerfile: docker/Dockerfile
     command: Frontend
+    ports:
+      - 8081:8081
 
+  # Expose the backend on http://localhost:8082
   backend:
-      build:
-        context: ../
-        dockerfile: docker/Dockerfile
-      command: Backend
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+    command: Backend
+    ports:
+      - 8082:8081


### PR DESCRIPTION
Simple addition to expose the `frontend` and `backend` services on ports 8081 and 8082, respectively.

I didn't see any contribution requirements, so let me know if there's anything you need in that regard.