### PR TITLE
Repackage backend and frontend as separate application jars

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,26 @@ Next, you can view traces that went through the backend via http://localhost:941
 * This is a locally run Zipkin service which keeps traces in memory
 
 ## Starting the Services
-In a separate tab or window, start each of [sleuth.webmvc.Frontend](/src/main/java/sleuth/webmvc/Frontend.java) and [sleuth.webmvc.Backend](/src/main/java/sleuth/webmvc/Backend.java):
+First build the project:
+
 ```bash
-$ ./mvnw compile exec:java -Dexec.mainClass=sleuth.webmvc.Backend
-$ ./mvnw compile exec:java -Dexec.mainClass=sleuth.webmvc.Frontend
+$ ./mvnw package
+```
+
+This builds two executable jar files in the `target` directory: `sleuth-example-backend.jar` and `sleuth-example-frontend.jar`.
+
+In a separate tab or window, start each of [sleuth.webmvc.Frontend](/src/main/java/sleuth/webmvc/Frontend.java) and [sleuth.webmvc.Backend](/src/main/java/sleuth/webmvc/Backend.java):
+
+```bash
+$ java -jar target/sleuth-example-backend.jar
+$ java -jar target/sleuth-example-frontend.jar
+```
+
+If you are making changes to the sample and you'd like to try them out, you can run the latest state as follows: 
+
+```bash
+$ ./mvnw spring-boot:run -Dspring-boot.run.main-class=sleuth.webmvc.Backend
+$ ./mvnw spring-boot:run -Dspring-boot.run.main-class=sleuth.webmvc.Frontend
 ```
 
 Next, run [Zipkin](https://zipkin.io/), which stores and queries traces reported by the above services.

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
   </dependencyManagement>
 
   <build>
+    <finalName>sleuth-example</finalName>
     <plugins>
       <plugin>
         <groupId>org.springframework.boot</groupId>
@@ -66,14 +67,27 @@
         <version>${spring-boot.version}</version>
         <executions>
           <execution>
+            <id>repackage-backend</id>
             <goals>
               <goal>repackage</goal>
             </goals>
+            <configuration>
+              <mainClass>sleuth.webmvc.Backend</mainClass>
+              <classifier>backend</classifier>
+            </configuration>
+          </execution>
+          <execution>
+            <id>repackage-frontend</id>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+            <configuration>
+              <mainClass>sleuth.webmvc.Frontend</mainClass>
+              <classifier>frontend</classifier>
+            </configuration>
           </execution>
         </executions>
         <configuration>
-          <mainClass>sleuth.webmvc.Backend</mainClass>
-          <classifier>exec</classifier>
           <executable>true</executable>
         </configuration>
       </plugin>


### PR DESCRIPTION
This commit updates the build configuration to produce a backend and
frontend executable jars to make it easier to get started. The README
has also been updated to mention the `spring-boot:run` plugin as it is
more idiomatic than using the exec plugin.